### PR TITLE
rabbitmq: add tcp nodelay

### DIFF
--- a/environments/kolla/files/overlays/rabbitmq/advanced.config
+++ b/environments/kolla/files/overlays/rabbitmq/advanced.config
@@ -3,6 +3,8 @@
     {inet_dist_listen_max, {{ role_rabbitmq_cluster_port }}},
     {inet_dist_listen_min, {{ role_rabbitmq_cluster_port }}},
     {inet_dist_use_interface, {% raw %}{{% endraw %}{{ api_interface_address | put_address_in_context('rabbitmq') }}}},
-    {net_ticktime, {{ rabbitmq_net_ticktime }}}
+    {net_ticktime, {{ rabbitmq_net_ticktime }}},
+    {inet_default_connect_options, [{nodelay, true}]},
+    {inet_default_listen_options,  [{nodelay, true}]}
   ]}
 ].

--- a/environments/kolla/files/overlays/rabbitmq/rabbitmq.conf
+++ b/environments/kolla/files/overlays/rabbitmq/rabbitmq.conf
@@ -50,3 +50,10 @@ vm_memory_high_watermark.relative = {{ rabbitmq_vm_memory_high_watermark_relativ
 
 # Use factor 1,5 of free disk space of total_memory_available_override_value
 disk_free_limit.relative = 1.5
+
+# See https://www.rabbitmq.com/docs/networking#tuning-for-large-number-of-connections-nodelay
+# This might help in reducing latency but can also improve throughput.
+# Increasing the existing tcp backlog to more than 128 connections not seems to be useful,
+# because this increases latency where another server can fulfill the request.
+# tcp_listen_options.backlog = 4096
+tcp_listen_options.nodelay = true


### PR DESCRIPTION
Activate TCP Nodelay based on https://www.rabbitmq.com/docs/networking#tuning-for-large-number-of-connections