### PR TITLE
Use an empty ansible.cfg

### DIFF
--- a/environments/ansible.cfg
+++ b/environments/ansible.cfg
@@ -1,43 +1,6 @@
 # All possible configuration parameters can be found in the Ansible documentation:
 #
 # https://docs.ansible.com/ansible/latest/reference_appendices/config.html
-
-[defaults]
-pipelining = true
-
-# hide deprecation warnings
-deprecation_warnings = false
-
-# hide "[WARNING]: Invalid characters were found in group names but not replaced,
-# use -vvvv to see details" warning message
-force_valid_group_names = ignore
-
-stdout_callback = osism.commons.still_alive
-
-host_key_checking = false
-
-# hide paramiko transport logging messages
-log_filter = paramiko.transport
-
-log_path=/ansible/logs/ansible.log
-private_key_file = /ansible/secrets/id_rsa.operator
-retry_files_enabled = false
-roles_path = /ansible/roles:/ansible/galaxy
-
-# Fact caching
-gathering = smart
-fact_caching = redis
-fact_caching_timeout = 86400
-fact_caching_connection = cache:6379:0
-
-# NO CHANGE OVER THIS LINE -- YOUR CHANGES WILL BE OVERWRITTEN
-###############################################################################
-
-# Customer-specific adjustments can be set here.
-remote_user = dragon
-
-###############################################################################
-# NO CHANGE UNDER THIS LINE -- YOUR CHANGES WILL BE OVERWRITTEN
-
-[ssh_connection]
-ssh_args = -o ControlMaster=auto -o ControlPersist=60s
+#
+# The defaults for the Ansible configuration can be found in the osism/defaults
+# repository. Values from there can be overwritten if they are listed in this file.


### PR DESCRIPTION
All content that is currently in it is already contained in the defaults and does not need to be replicated here.