### PR TITLE
Remove releasenotes directory from environments

### DIFF
--- a/environments/releasenotes/notes/remove-osism-serial-parameters-ebd09df2eb95d6b6.yaml
+++ b/environments/releasenotes/notes/remove-osism-serial-parameters-ebd09df2eb95d6b6.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    The `osism_serial_*` parameters have been removed. The defaults from
-    osism/defaults are fine.


### PR DESCRIPTION
It doesn't belong there and seems to have sneaked in.